### PR TITLE
Update tracer.cc

### DIFF
--- a/tracer.cc
+++ b/tracer.cc
@@ -114,9 +114,9 @@ static void callback_reset(qemu_plugin_id_t id)
 
 static void tb_exec(unsigned int cpu_index, void *udata)
 {
-    uint64_t interval = inst_count / INTERVAL_SIZE;
-
     lock.lock();
+    
+    uint64_t interval = inst_count / INTERVAL_SIZE;
 
     if (tracing_enabled) {
         if (inst_dumped > INTERVAL_SIZE) {


### PR DESCRIPTION
need lock of all shared global vars.

Prior to the modifications, the bbv.gz files generated by QEMU were different with each input, resulting in distinct simpoints and weights after SimPoint analysis. 
After modifications, the bbv.gz and simpoints generated are now consistently identical each time.